### PR TITLE
Size option

### DIFF
--- a/Screenkey/screenkey.py
+++ b/Screenkey/screenkey.py
@@ -60,7 +60,7 @@ class Screenkey(gtk.Window):
     STATE_FILE = os.path.join(glib.get_user_cache_dir(), 
                               'screenkey.dat')
 
-    def __init__(self, logger, nodetach, nohide, bg, fg, nosudo, window_id):
+    def __init__(self, logger, nodetach, nohide, bg, fg, size, nosudo, window_id):
         gtk.Window.__init__(self)
         self.timer = None
         self.logger = logger
@@ -70,7 +70,7 @@ class Screenkey(gtk.Window):
             self.options = {
                 'timeout': 2.5,
                 'position': POS_BOTTOM,
-                'size': SIZE_SMALL,
+                'size': size,
                 'mode': MODE_NORMAL,
                 }
 

--- a/screenkey
+++ b/screenkey
@@ -44,6 +44,8 @@ def Main():
         dest="bg", default="black", help=_("background color (in #RRGGBB format)"))
     parser.add_option("--fg", action="store",
         dest="fg", default="white", help=_("foreground color"))
+    parser.add_option("-s", "--size", type="int",
+        dest="size", default=2, help=_("size (small=2, medium=1, large=0)"))
     parser.add_option("--no-sudo", action="store_true",
         dest="nosudo", default="white",
         help=_("do not perform very expensive sudo running check"))
@@ -70,7 +72,7 @@ def Main():
 
     s = Screenkey(logger=logger, nodetach=options.nodetach,
         nohide=options.nohide,
-        bg=options.bg, fg=options.fg,
+        bg=options.bg, fg=options.fg, size=options.size,
         nosudo=options.nosudo,
         window_id=options.window_id)
     try:


### PR DESCRIPTION
I added a very simple command-line option for choosing the size. Ideally the user could input "small", "medium", "large" or even a number from 0 to 1, but in order to keep it succinct, I simply used the built-in values of 0, 1 and 2.
